### PR TITLE
git checkout with submodules and use codeql v2

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -53,6 +55,6 @@ jobs:
           sarif-output: sarif
 
       - name: Upload SARIF file(s)
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: sarif


### PR DESCRIPTION
* actions/checkout should checkout submodules. Building may fail otherwise
* github/codeql-action/upload-sarif@v1 has been updated to github/codeql-action/upload-sarif@v2
